### PR TITLE
refactor: standardize generative AI architecture

### DIFF
--- a/services/ai/BaseGenerativeAI.ts
+++ b/services/ai/BaseGenerativeAI.ts
@@ -1,0 +1,18 @@
+/**
+ * Base contract for generative AI implementations.
+ */
+export abstract class BaseGenerativeAI {
+  /**
+   * Generates a text completion from a given prompt.
+   *
+   * @param prompt - Text prompt to send to the model.
+   */
+  public abstract generateText<TResponse>(prompt: string): Promise<TResponse>;
+
+  /**
+   * Generates an image from a given prompt.
+   *
+   * @param prompt - Text prompt to send to the model.
+   */
+  public abstract generateImage<TResponse>(prompt: string): Promise<TResponse>;
+}

--- a/services/ai/GenerativeAI.ts
+++ b/services/ai/GenerativeAI.ts
@@ -1,5 +1,0 @@
-export abstract class GenerativeAI {
-  public abstract generateText<TResponse>(prompt: string): Promise<any>;
-
-  public abstract generateImage<IResponse>(prompt: string): Promise<any>;
-}

--- a/services/ai/GenerativeAIProvider.ts
+++ b/services/ai/GenerativeAIProvider.ts
@@ -1,19 +1,23 @@
-import type { GenerativeAI } from '~/services/ai/GenerativeAI';
+import type { BaseGenerativeAI } from '~/services/ai/BaseGenerativeAI';
 import { GoogleGenerativeAIImpl } from '~/services/ai/GoogleGenerativeAIImpl';
 
 export class GenerativeAIProvider {
-  private client: GenerativeAI;
+  private client: BaseGenerativeAI;
 
   constructor() {
     this.client = new GoogleGenerativeAIImpl();
   }
 
-  setClient(client: GenerativeAI) {
+  setClient(client: BaseGenerativeAI) {
     this.client = client;
     return this.client;
   }
 
-  async generateText<String>(prompt: string): Promise<String> {
-    return this.client.generateText(prompt);
+  async generateText<TResponse>(prompt: string): Promise<TResponse> {
+    return this.client.generateText<TResponse>(prompt);
+  }
+
+  async generateImage<TResponse>(prompt: string): Promise<TResponse> {
+    return this.client.generateImage<TResponse>(prompt);
   }
 }

--- a/services/ai/GoogleGenerativeAIImpl.ts
+++ b/services/ai/GoogleGenerativeAIImpl.ts
@@ -1,7 +1,7 @@
 //@ts-ignore
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { logDev } from '~/core/helpers/log';
-import type { BaseGenerativeAI } from '~/services/ai/base_generative_ai';
+import type { BaseGenerativeAI } from '~/services/ai/BaseGenerativeAI';
 
 export class GoogleGenerativeAIImpl implements BaseGenerativeAI {
   private genAI: GoogleGenerativeAI;
@@ -14,11 +14,11 @@ export class GoogleGenerativeAIImpl implements BaseGenerativeAI {
     this.genAI = new GoogleGenerativeAI(googleGenerativeApiKey);
   }
 
-  generateImage(prompt: string): Promise<any> {
-    return Promise.resolve(undefined);
+  generateImage<TResponse>(prompt: string): Promise<TResponse> {
+    return Promise.resolve(undefined as unknown as TResponse);
   }
 
-  async generateText(prompt: string): Promise<any> {
+  async generateText<TResponse>(prompt: string): Promise<TResponse> {
     // For text-only input, use the gemini-pro model
     const model = this.genAI.getGenerativeModel({ model: 'gemini-1.5-pro' });
 
@@ -26,6 +26,6 @@ export class GoogleGenerativeAIImpl implements BaseGenerativeAI {
     const response = await result.response;
 
     logDev('RESPONSE', response);
-    return response.text();
+    return response.text() as TResponse;
   }
 }

--- a/services/ai/index.ts
+++ b/services/ai/index.ts
@@ -1,0 +1,3 @@
+export { BaseGenerativeAI } from './BaseGenerativeAI';
+export { GenerativeAIProvider } from './GenerativeAIProvider';
+export { GoogleGenerativeAIImpl } from './GoogleGenerativeAIImpl';


### PR DESCRIPTION
## Summary
- introduce `BaseGenerativeAI` interface and update provider/implementation
- expose AI services through a barrel export

## Testing
- `yarn build` *(fails: Could not initialize provider fontshare/fontsource: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d0671f6fc83338646122a1206ae72